### PR TITLE
Update Table for 1st December

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -22,6 +22,7 @@ def ss(timestamp: str, hh: int, reward: int):
 SAVING_SESSIONS = [
     ss("2023-11-16 17:30", 2, 1800),
     ss("2023-11-29 17:00", 3, 3200),
+    ss("2023-12-01 16:30", 2, 3200),
 ]
 
 


### PR DESCRIPTION
The next Saving Session:
Tomorrow for 1 hour and 30 minutes between 16:30 - 18:00

Opt in now to earn 3200 Octopoints - worth £4.00 - for every unit of power you save.